### PR TITLE
Fix superscript formatting

### DIFF
--- a/04.-general-statements.md
+++ b/04.-general-statements.md
@@ -2,7 +2,7 @@
 
 The Information Model and its renderings MUST treat strings, both entity and attribute names and their values, as being case-sensitive. Each GLUE entity MUST have an ID attribute \(an exception is made for the Extension class\) which is needed for identification or for access to the attributes of the related entity over time and across different information sources. As a general guideline, ID's SHOULD be persistent at least for a day when assigned to an entity. The ID MUST NOT be interpreted by the user or the system as having any meaning other than an identifier. In particular, there is no relationship between an ID and a network endpoint. Every ID MUST be a valid URI. The usage of URN \(Uniform Resource Name, a subset of Uniform Resource Identifier or URI\) is RECOMMENDED. The motivations for choosing URI’s reside in the fact that Grid services are evolving towards Web-based technologies, therefore it is meaningful to adopt the same identification system.
 
-As regards units of measure, multiples of bytes MUST refer to the SI \(_Le_ _**S**ystème_ _**I**nternational d'Unités_\) prefix \(http://en.wikipedia.org/wiki/SI\_prefix\), therefore GB is 109 Bytes and not 230 Bytes \(the latter are GibiBytes\).
+As regards units of measure, multiples of bytes MUST refer to the SI \(_Le_ _**S**ystème_ _**I**nternational d'Unités_\) prefix \(http://en.wikipedia.org/wiki/SI\_prefix\), therefore GB is 10{% sup %}9{% endsup %} Bytes and not 2{% sup %}30{% endsup %} Bytes \(the latter are GibiBytes\).
 
 In Appendix A, we provide guidelines for place-holder values that MUST be used when the attributes have no good default value or when the attribute cannot be measured for some reason.
 

--- a/book.json
+++ b/book.json
@@ -1,0 +1,3 @@
+{
+    "plugins": ["superscript"]
+}


### PR DESCRIPTION
Add plugin to support superscript text via markup like:

    Hello world. {% sup %}superscript text!{% endsup %}

Fix rendering X-to-the-power-of-Y terms, the exponent (Y) is using
written in super-script.

Fixes OpenGridForum/OGF-GLUE-2.1-test#1